### PR TITLE
Fix: 카카오 앱 로그인 후 토큰 로그인 기능 수정

### DIFF
--- a/genti-api/src/main/java/com/gt/genti/auth/controller/AuthController.java
+++ b/genti-api/src/main/java/com/gt/genti/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.gt.genti.auth.dto.request.AppleLoginRequest;
 import com.gt.genti.auth.dto.request.AppleLoginRequestDto;
-import com.gt.genti.auth.dto.request.OauthSignRequestDto;
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequestImpl;
 import com.gt.genti.auth.dto.request.TokenRefreshRequestDto;
 import com.gt.genti.auth.dto.response.OauthJwtResponse;
@@ -153,9 +153,8 @@ public class AuthController {
 	@PostMapping("/login/oauth2/token")
 	@Logging(item = LogItem.OAUTH_APP, action = LogAction.LOGIN, requester = LogRequester.ANONYMOUS)
 	public ResponseEntity<ApiResult<OauthJwtResponse>> loginOrSignUpWithOAuthToken(
-		@RequestBody @Valid OauthSignRequestDto oauthSignRequestDto) {
-		return success(authService.appLogin(SocialLoginRequestImpl.of(oauthSignRequestDto.getOauthPlatform(),
-			oauthSignRequestDto.getToken())));
+		@RequestBody @Valid SocialAppLoginRequest socialAppLoginRequest) {
+		return success(authService.appLogin(socialAppLoginRequest));
 	}
 
 	@PostMapping("/reissue")

--- a/genti-api/src/main/java/com/gt/genti/auth/dto/request/SocialAppLoginRequest.java
+++ b/genti-api/src/main/java/com/gt/genti/auth/dto/request/SocialAppLoginRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(name = "[Auth][Anonymous] oauth 토큰으로 로그인or회원가입 처리 요청 dto", description = "Oauth 토큰 및 플랫폼")
-public class OauthSignRequestDto {
+public class SocialAppLoginRequest {
 	@NotBlank
 	@Schema(example = "rhtodaksgdkdyekemf")
 	String token;

--- a/genti-api/src/main/java/com/gt/genti/auth/service/AuthService.java
+++ b/genti-api/src/main/java/com/gt/genti/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequest;
 import com.gt.genti.auth.dto.request.TokenRefreshRequestDto;
 import com.gt.genti.auth.dto.response.OauthJwtResponse;
@@ -20,6 +21,7 @@ import com.gt.genti.user.repository.UserRepository;
 import com.gt.genti.user.service.social.SocialOauthContext;
 import com.gt.genti.util.HttpRequestUtil;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,8 +38,8 @@ public class AuthService {
 		return socialOauthContext.doLogin(request);
 	}
 
-	public OauthJwtResponse appLogin(final SocialLoginRequest request) {
-		return socialOauthContext.doLogin(request).getToken();
+	public OauthJwtResponse appLogin(final @Valid SocialAppLoginRequest request) {
+		return socialOauthContext.doAppLogin(request).getToken();
 	}
 
 	public HttpHeaders getOauthRedirect(OauthPlatform oauthPlatform) {

--- a/genti-api/src/main/java/com/gt/genti/auth/service/AuthService.java
+++ b/genti-api/src/main/java/com/gt/genti/auth/service/AuthService.java
@@ -21,7 +21,6 @@ import com.gt.genti.user.repository.UserRepository;
 import com.gt.genti.user.service.social.SocialOauthContext;
 import com.gt.genti.util.HttpRequestUtil;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,7 +37,7 @@ public class AuthService {
 		return socialOauthContext.doLogin(request);
 	}
 
-	public OauthJwtResponse appLogin(final @Valid SocialAppLoginRequest request) {
+	public OauthJwtResponse appLogin(final SocialAppLoginRequest request) {
 		return socialOauthContext.doAppLogin(request).getToken();
 	}
 

--- a/genti-api/src/main/java/com/gt/genti/user/service/social/AppleOauthStrategy.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/AppleOauthStrategy.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequest;
+import com.gt.genti.auth.dto.request.SocialLoginRequestImpl;
 import com.gt.genti.auth.dto.response.OauthJwtResponse;
 import com.gt.genti.auth.dto.response.SocialLoginResponse;
 import com.gt.genti.error.ExpectedException;
@@ -45,7 +47,7 @@ public class AppleOauthStrategy implements SocialLoginStrategy {
 
 	@Override
 	@Transactional
-	public SocialLoginResponse login(SocialLoginRequest request) {
+	public SocialLoginResponse webLogin(SocialLoginRequest request) {
 		AppleUserResponse userResponse = getApplePlatformMember(request.getCode());
 		Optional<User> findUser = userRepository.findUserBySocialId(userResponse.getPlatformId());
 		User user;
@@ -70,9 +72,15 @@ public class AppleOauthStrategy implements SocialLoginStrategy {
 			.userId(user.getId().toString())
 			.role(user.getUserRole().getRoles())
 			.build();
-		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
+		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(
+			jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
 			jwtTokenProvider.generateRefreshToken(tokenGenerateCommand), user.getUserRole());
 		return SocialLoginResponse.of(user.getId(), user.getUsername(), user.getEmail(), isNewUser, oauthJwtResponse);
+	}
+
+	@Override
+	public SocialLoginResponse tokenLogin(SocialAppLoginRequest request) {
+		return webLogin(SocialLoginRequestImpl.of(request.getOauthPlatform(), request.getToken()));
 	}
 
 	@Override

--- a/genti-api/src/main/java/com/gt/genti/user/service/social/GoogleOauthStrategy.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/GoogleOauthStrategy.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequest;
 import com.gt.genti.auth.dto.response.OauthJwtResponse;
 import com.gt.genti.auth.dto.response.SocialLoginResponse;
@@ -69,7 +70,7 @@ public class GoogleOauthStrategy implements SocialLoginStrategy, SocialAuthStrat
 
 	@Override
 	@Transactional
-	public SocialLoginResponse login(SocialLoginRequest request) {
+	public SocialLoginResponse webLogin(SocialLoginRequest request) {
 		GoogleTokenResponse tokenResponse = googleAuthApiClient.googleAuth(
 			request.getCode(),
 			googleClientId,
@@ -103,6 +104,11 @@ public class GoogleOauthStrategy implements SocialLoginStrategy, SocialAuthStrat
 		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
 			jwtTokenProvider.generateRefreshToken(tokenGenerateCommand), user.getUserRole());
 		return SocialLoginResponse.of(user.getId(), user.getUsername(), user.getEmail(), isNewUser, oauthJwtResponse);
+	}
+
+	@Override
+	public SocialLoginResponse tokenLogin(SocialAppLoginRequest request) {
+		return null;
 	}
 
 	@Override

--- a/genti-api/src/main/java/com/gt/genti/user/service/social/KakaoOauthStrategy.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/KakaoOauthStrategy.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequest;
 import com.gt.genti.auth.dto.response.OauthJwtResponse;
 import com.gt.genti.auth.dto.response.SocialLoginResponse;
@@ -65,7 +66,7 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 
 	@Override
 	@Transactional
-	public SocialLoginResponse login(SocialLoginRequest request) {
+	public SocialLoginResponse webLogin(SocialLoginRequest request) {
 		KakaoTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
 			"authorization_code",
 			kakaoClientId,
@@ -73,8 +74,20 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 			serverBaseUri + ":" + serverPort + kakaoRedirectUri,
 			request.getCode()
 		);
+
+		OauthPlatform oauthPlatform = request.getOauthPlatform();
+		String accessToken = tokenResponse.accessToken();
+		return getUserInfo(oauthPlatform, accessToken);
+	}
+
+	@Override
+	public SocialLoginResponse tokenLogin(final SocialAppLoginRequest request) {
+		return getUserInfo(request.getOauthPlatform(), request.getToken());
+	}
+
+	private SocialLoginResponse getUserInfo(OauthPlatform oauthPlatform, String accessToken) {
 		KakaoUserResponse userResponse = kakaoApiClient.getUserInformation(
-			"Bearer " + tokenResponse.accessToken());
+			"Bearer " + accessToken);
 		Optional<User> findUser = userRepository.findUserBySocialId(userResponse.id());
 		User user;
 		boolean isNewUser = false;
@@ -82,7 +95,7 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 			User newUser = userRepository.save(User.builderWithSignIn()
 				.socialId(userResponse.id())
 				.birthDate(getBirthDateStringFrom(userResponse))
-				.oauthPlatform(request.getOauthPlatform())
+				.oauthPlatform(oauthPlatform)
 				.username(userResponse.kakaoAccount().name())
 				.nickname(RandomUtil.generateRandomNickname())
 				.email(userResponse.kakaoAccount().email())
@@ -99,7 +112,8 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 			.userId(user.getId().toString())
 			.role(user.getUserRole().getRoles())
 			.build();
-		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
+		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(
+			jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
 			jwtTokenProvider.generateRefreshToken(tokenGenerateCommand), user.getUserRole());
 		return SocialLoginResponse.of(user.getId(), user.getUsername(), user.getEmail(), isNewUser, oauthJwtResponse);
 	}

--- a/genti-api/src/main/java/com/gt/genti/user/service/social/SocialLoginStrategy.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/SocialLoginStrategy.java
@@ -1,11 +1,13 @@
 package com.gt.genti.user.service.social;
 
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequest;
 import com.gt.genti.auth.dto.response.SocialLoginResponse;
 
 public interface SocialLoginStrategy {
 
-    SocialLoginResponse login(final SocialLoginRequest request);
+    SocialLoginResponse webLogin(final SocialLoginRequest request);
+    SocialLoginResponse tokenLogin(final SocialAppLoginRequest request);
     boolean support(String provider);
 
 }

--- a/genti-api/src/main/java/com/gt/genti/user/service/social/SocialOauthContext.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/SocialOauthContext.java
@@ -5,13 +5,15 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.gt.genti.error.ExpectedException;
-import com.gt.genti.error.ResponseCode;
+import com.gt.genti.auth.dto.request.SocialAppLoginRequest;
 import com.gt.genti.auth.dto.request.SocialLoginRequest;
 import com.gt.genti.auth.dto.response.SocialLoginResponse;
+import com.gt.genti.error.ExpectedException;
+import com.gt.genti.error.ResponseCode;
 import com.gt.genti.user.model.OauthPlatform;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -48,11 +50,14 @@ public class SocialOauthContext {
 	}
 
 	public SocialLoginResponse doLogin(final SocialLoginRequest request) {
-		return loginStrategyOf(request.getOauthPlatform()).login(request);
+		return loginStrategyOf(request.getOauthPlatform()).webLogin(request);
 	}
 
 	public String getAuthUri(OauthPlatform oauthPlatform) {
 		return authStrategyOf(oauthPlatform).getAuthUri();
 	}
 
+	public SocialLoginResponse doAppLogin(@Valid SocialAppLoginRequest request) {
+		return loginStrategyOf(request.getOauthPlatform()).tokenLogin(request);
+	}
 }


### PR DESCRIPTION
- 애플 : 웹 로그인 자체가 존재하지 않음, 현재 webLogin 메서드에서 앱 토큰 로그인 수행
- 카카오 : 웹 로그인의 경우 기존대로 webLogin 로직 수행, 앱 로그인의 경우 appLogin 수행