### PR TITLE
Fix: Oauth redirect url 프로퍼티 읽어오는 방식 수정

### DIFF
--- a/genti-api/src/main/java/com/gt/genti/user/service/social/GoogleOauthStrategy.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/GoogleOauthStrategy.java
@@ -38,10 +38,6 @@ public class GoogleOauthStrategy implements SocialLoginStrategy, SocialAuthStrat
 	private String googleClientSecret;
 	@Value("${google.redirect-url}")
 	private String googleRedirectUrl;
-	@Value("${server.domain}")
-	private String serverBaseUri;
-	@Value("${server.port}")
-	private String serverPort;
 
 	@Value("${google.scope}")
 	private List<String> scope;
@@ -57,7 +53,7 @@ public class GoogleOauthStrategy implements SocialLoginStrategy, SocialAuthStrat
 	public String getAuthUri() {
 		Map<String, Object> params = new HashMap<>();
 		params.put("client_id", googleClientId);
-		params.put("redirect_uri", serverBaseUri + ":" + serverPort + googleRedirectUrl);
+		params.put("redirect_uri", googleRedirectUrl);
 		params.put("response_type", "code");
 		params.put("scope", String.join("%20", scope));
 
@@ -74,7 +70,7 @@ public class GoogleOauthStrategy implements SocialLoginStrategy, SocialAuthStrat
 			request.getCode(),
 			googleClientId,
 			googleClientSecret,
-			serverBaseUri + ":" + serverPort + googleRedirectUrl,
+			googleRedirectUrl,
 			"authorization_code"
 		);
 		GoogleInfoResponse userResponse = googleApiClient.googleInfo("Bearer " + tokenResponse.accessToken());

--- a/genti-api/src/main/java/com/gt/genti/user/service/social/KakaoOauthStrategy.java
+++ b/genti-api/src/main/java/com/gt/genti/user/service/social/KakaoOauthStrategy.java
@@ -36,10 +36,6 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 	private String kakaoClientId;
 	@Value("${kakao.redirect-uri}")
 	private String kakaoRedirectUri;
-	@Value("${server.domain}")
-	private String serverBaseUri;
-	@Value("${server.port}")
-	private String serverPort;
 	@Value("${kakao.client-secret}")
 	private String kakaoClientSecret;
 
@@ -54,7 +50,7 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 	public String getAuthUri() {
 		Map<String, Object> params = new HashMap<>();
 		params.put("client_id", kakaoClientId);
-		params.put("redirect_uri", serverBaseUri + ":" + serverPort + kakaoRedirectUri);
+		params.put("redirect_uri", kakaoRedirectUri);
 		params.put("response_type", "code");
 
 		String paramStr = params.entrySet().stream()
@@ -70,7 +66,7 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 			"authorization_code",
 			kakaoClientId,
 			kakaoClientSecret,
-			serverBaseUri + ":" + serverPort + kakaoRedirectUri,
+			kakaoRedirectUri,
 			request.getCode()
 		);
 		KakaoUserResponse userResponse = kakaoApiClient.getUserInformation(
@@ -99,7 +95,8 @@ public class KakaoOauthStrategy implements SocialLoginStrategy, SocialAuthStrate
 			.userId(user.getId().toString())
 			.role(user.getUserRole().getRoles())
 			.build();
-		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
+		OauthJwtResponse oauthJwtResponse = new OauthJwtResponse(
+			jwtTokenProvider.generateAccessToken(tokenGenerateCommand),
 			jwtTokenProvider.generateRefreshToken(tokenGenerateCommand), user.getUserRole().getStringValue());
 		return SocialLoginResponse.of(user.getId(), user.getUsername(), user.getEmail(), isNewUser, oauthJwtResponse);
 	}


### PR DESCRIPTION
- 스프링의 기본 property를 참고하지 않도록 변경 server.port, server.url
왜냐하면 스프링이 실제로 동작할 포트는 local이나 운영환경이나 8080이라서  기존과 같은 방식으로 oauth provider에게 redirecturl 전달시 https://genti.kr:8080/~~~ 과 같은 끔찍한 혼종이 발생합니다