### PR TITLE
Feat #56 예외 Discord Appender 수정

### DIFF
--- a/genti-external/src/main/java/com/gt/genti/discord/DiscordAppender.java
+++ b/genti-external/src/main/java/com/gt/genti/discord/DiscordAppender.java
@@ -54,7 +54,13 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 		log.info("{}", eventObject.getMessage());
 
 		if (throwable != null) {
-			exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage();
+			if(throwable instanceof ExpectedException expectedException) {
+				exceptionBrief += expectedException.getClass().getSimpleName() + " : ";
+				exceptionBrief += expectedException.getResponseCode().name() + " : ";
+				exceptionBrief += expectedException.getResponseCode().getErrorCode();
+			} else{
+				exceptionBrief = throwable.getClass().getSimpleName() + " : " + throwable.getMessage();
+			}
 		}
 
 		if (exceptionBrief.isEmpty()) {
@@ -121,7 +127,7 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
 		if (throwable != null) {
 			exceptionDetail = ThrowableProxyUtil.asString(throwable);
-			String exception = exceptionDetail.substring(0, 4000);
+			String exception = exceptionDetail.substring(0, 500);
 			discordWebhook.addEmbed(
 				EmbedObject.builder()
 					.title("[Exception 상세 내용]")


### PR DESCRIPTION
- #56 
- 예외 상세 내용 4000 -> 500자 제한
- ExpectedException 대신 ResponseCode 내용을 알림
